### PR TITLE
fix(deploy): fix the frontend paths

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -17,11 +17,11 @@ objects:
       deploymentRepo: https://github.com/RedHatInsights/insights-runtimes-frontend
       frontend:
         paths:
-          - /apps/insights-runtimes-frontend
+          - /apps/runtimes
       image: ${IMAGE}:${IMAGE_TAG}
 
       module:
-        manifestLocation: '/apps/insights-runtimes-frontend/fed-mods.json'
+        manifestLocation: '/apps/runtimes/fed-mods.json'
         # modules:
         #   - id: 'overview'
         #     module: './RootApp'


### PR DESCRIPTION
When running the application the expected path at the moment is `apps/runtimes`, and this change reflects that.