### PR TITLE
fix(deploy): change the metadata name to runtimes

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -7,7 +7,7 @@ objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: Frontend
     metadata:
-      name: insights-runtimes-frontend
+      name: runtimes
     spec:
       API:
         versions:


### PR DESCRIPTION
When deployed in Ephemeral I noticed that the deployment was named `insights-runtimes-frontend-frontend`, which is different from how the other frontends were named `${APP_NAME}-frontend`. From comparing a few `deploy.sh` scripts from different apps it looks like it's likely caused by the metadata > name field, will verify in Ephemeral once this change is up.