### PR TITLE
chore(accordion): use application name as accordion title for general Java apps

### DIFF
--- a/src/api/interfaces.ts
+++ b/src/api/interfaces.ts
@@ -6,6 +6,7 @@ export interface RuntimesInventoryResponse {
  * Interfaces borrowed from insights-runtimes-inventory
  */
 export interface JvmInstance {
+  title?: string; // will be set by utils.js as the title for the Runtimes Accordion entry
   id: string;
   accountId: string;
   appName?: string;

--- a/src/components/RuntimesProcessesAccordion.test.tsx
+++ b/src/components/RuntimesProcessesAccordion.test.tsx
@@ -3,20 +3,25 @@ import { fireEvent, render } from '@testing-library/react';
 import RuntimesProcessesAccordion from './RuntimesProcessesAccordion';
 import '@testing-library/jest-dom';
 import { fooInstance, mockInstance } from '../utils/test-utils';
+import { formatInstancesData } from '../utils/utils';
 
 describe('Runtimes Processes Accordion', () => {
   it('should display instance information', () => {
     const { container } = render(
-      <RuntimesProcessesAccordion instances={[mockInstance]} />
+      <RuntimesProcessesAccordion
+        instances={formatInstancesData([mockInstance])}
+      />
     );
     expect(
       container.querySelector('.pf-v5-c-accordion__toggle-text')?.innerHTML
-    ).toEqual(mockInstance.workload);
+    ).toEqual(mockInstance.title);
   });
 
   it('should be expanded if there is only one response', () => {
     const { container } = render(
-      <RuntimesProcessesAccordion instances={[mockInstance]} />
+      <RuntimesProcessesAccordion
+        instances={formatInstancesData([mockInstance])}
+      />
     );
     expect(
       container
@@ -27,7 +32,9 @@ describe('Runtimes Processes Accordion', () => {
 
   it('should not be expanded if there is more than one', () => {
     const { container } = render(
-      <RuntimesProcessesAccordion instances={[fooInstance, mockInstance]} />
+      <RuntimesProcessesAccordion
+        instances={formatInstancesData([fooInstance, mockInstance])}
+      />
     );
     expect(
       container
@@ -38,7 +45,9 @@ describe('Runtimes Processes Accordion', () => {
 
   it('should toggle row expansion when clicked', () => {
     const { container } = render(
-      <RuntimesProcessesAccordion instances={[mockInstance]} />
+      <RuntimesProcessesAccordion
+        instances={formatInstancesData([mockInstance])}
+      />
     );
     const fooButton = container.querySelector('#instance-0-toggle');
     if (!fooButton) {

--- a/src/components/RuntimesProcessesAccordion.tsx
+++ b/src/components/RuntimesProcessesAccordion.tsx
@@ -74,7 +74,7 @@ const RuntimesProcessesAccordion = ({
                   columnGap: 16,
                 }}
               >
-                {instance.workload}
+                {instance.title}
               </AccordionToggle>
               <AccordionContent
                 isHidden={!expanded.includes(`instance-${index}-toggle`)}
@@ -91,18 +91,18 @@ const RuntimesProcessesAccordion = ({
                       return (
                         <Fragment key={`${row.id} title`}>
                           <TextListItem
-                            id={`${instance.workload}-${row.id}-title`}
+                            id={`${instance.title}-${row.id}-title`}
                             key={`${row.id} title`}
                             component={TextListItemVariants.dt}
-                            aria-label={`${instance.workload} ${row.id} title`}
+                            aria-label={`${instance.title} ${row.id} title`}
                           >
                             {row.title}
                           </TextListItem>
                           <TextListItem
-                            id={`${instance.workload}-${row.id}-value`}
+                            id={`${instance.title}-${row.id}-value`}
                             key={`${row.id} value`}
                             component={TextListItemVariants.dd}
-                            aria-label={`${instance.workload} ${row.id} value`}
+                            aria-label={`${instance.title} ${row.id} value`}
                           >
                             {instance[row.id as keyof typeof instance]}
                           </TextListItem>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -16,13 +16,15 @@ export const mergeToBasename = (to: To, basename: string): To => {
 
 export const formatInstancesData = (instances: JvmInstance[]) => {
   instances.forEach((instance) => {
+    instance.title = instance.workload;
     // add the appName value to a JvmInstance
     if (!instance['appName']) {
       instance.appName = instance.details['app.name'];
     }
-    // change the unidentified workload type
+    // change the unidentified workload type, and set the title to the application name
     if (instance.workload === 'Unidentified') {
-      instance.workload = `General Java Application (${instance.appName})`;
+      instance.workload = `General Java Application`;
+      instance.title = instance.appName;
     }
     // format the date string
     instance.created = new Date(instance.created).toLocaleString();


### PR DESCRIPTION
This PR adds a new entry into the frontend JvmInstance interface to allow for a title that will be used in the accordion, instead of just using the workload. This let's us have more control over the title without appending extra strings to the workload. It still keeps the `unidientified` -> `General Java Application` change, but will now display the app name instead of the longer string.

Unit tests also updated to use the same utils formatting function that's used to adjust the instance data prior to displaying in the accordion too.

Example:
![Screenshot from 2024-04-11 10-56-43](https://github.com/RedHatInsights/insights-runtimes-frontend/assets/10425301/069b733f-30b2-4b7e-a6a8-cb135a642cea)
