### PR TITLE
fix(utils): handle potentially invalid date time strings

### DIFF
--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,22 @@
+import '@testing-library/jest-dom';
+import { formatDateTimeString } from './utils';
+
+describe('Utilities', () => {
+  describe('formatDateTimeString()', () => {
+    it('should format simplified ISO-8061 date time strings', () => {
+      const datestring = '2024-02-21T20:14:29.380Z';
+      expect(formatDateTimeString(datestring)).not.toEqual('Invalid Date');
+    });
+
+    it('should handle ISO-8061 ZonedDateTime strings from Java', () => {
+      const datestring = '2024-02-21T20:14:29.380397Z';
+      expect(formatDateTimeString(datestring)).not.toEqual('Invalid Date');
+    });
+
+    it('should return the passed value as a fallback', () => {
+      // RFC-3339 Date Time String
+      const datestring = '2024-02-21T20:14:29.38-05:00';
+      expect(formatDateTimeString(datestring)).toBe(datestring);
+    });
+  });
+});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -27,7 +27,7 @@ export const formatInstancesData = (instances: JvmInstance[]) => {
       instance.title = instance.appName;
     }
     // format the date string
-    instance.created = new Date(instance.created).toLocaleString();
+    instance.created = formatDateTimeString(instance.created);
     // format the GC details string
     const regex = new RegExp('gc::(.*?)::(.*?)$');
     const match = regex.exec(instance.jvmHeapGcDetails);
@@ -36,4 +36,48 @@ export const formatInstancesData = (instances: JvmInstance[]) => {
     }
   });
   return instances;
+};
+
+/**
+ * Function that tries to convert a date string into a Date object, and returns a locale date string.
+ * The incoming date string can be a timestamp string, or a type of Date Time string.
+ *
+ * The runtimes-inventory backend stores the "created" time as a Java ZonedDateTime, which follows the
+ * the ISO-8601 calendar system in the format YYYY-MM-DDTHH:MM:ss.ssssssZ, with the milliseconds at 6 digits.
+ *
+ * See: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/ZonedDateTime.html
+ *
+ * The JavaScript Date constructor can parse date time strings, but expects a ECMA Date Time String format,
+ * which is a simplification of the ISO-8601 format that only counts to three millisecond digits:
+ * YYYY-MM-DDTHH:mm:ss.sssZ.
+ *
+ * See: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-time-string-format
+ *
+ * This function attempts to pass the Java ZonedDateTime string into the JavaScript Date constructor,
+ * and convert it into a locale string. If the resulting string is 'Invalid Date' then the formatting
+ * of the ZonedDateTime failed, and will try to use a regex to grab the simplified Date Time String
+ * from the ZonedDateTime. If that fails, it will just return the ZonedDateTime string as written.
+ *
+ */
+export const formatDateTimeString = (date: string) => {
+  let datestring = new Date(date).toLocaleString();
+  // let datestring = 'Invalid Date';
+  if (datestring === 'Invalid Date') {
+    const regex = new RegExp(
+      '^([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3})[0-9]{3}(Z|[+-][0-9]{2}:[0-9]{2})$'
+    );
+    const match = regex.exec(date);
+    if (match && match[1] && match[2]) {
+      datestring = new Date(
+        match[1].valueOf().concat(match[2].valueOf())
+      ).toLocaleString();
+      if (datestring === 'Invalid Date') {
+        // if the regex capture works but still results in an invalid date, just return the ISO-8061
+        datestring = date;
+      }
+    }
+  } else {
+    datestring = date;
+  }
+  return datestring;
 };


### PR DESCRIPTION
In the review for https://github.com/RedHatInsights/insights-inventory-frontend/pull/2177, it was found that the value of "Created" could be displayed as "Invalid Date". Taking a deeper look, this happens if a date object has the value `NaN` and we try to get a formatted string out of it. The main culprit looks to be the Date constructor, which can parse a date string and convert it into a Date object.

The JvmInstance.created is coming back as the string representation of a ZonedDateTime (https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/ZonedDateTime.html) object, which is in the format ISO-8061 (although from digging around a bit it is also referenced as the RFC 3339 format, which seems to be an extension on the base ISO-8061).

The Date constructor is expecting a simplifed ISO-8061 format as per the ECMA documentation (https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-time-string-format). The difference being that ZonedDateTime will have the milliseconds set to 6 digits, but the JavaScript is expecting 3.

In practice I haven't actually seen this error, but I think this is where all the information I'm looking at is pointing to. As a result, I've added an extra function that will format the incoming ZonedDateTime string. First it tries to convert it as before, but checks to see if the resulting date string is 'Invalid Date' or not. If it is invalid, then it'll use regex to match and capture groups that omit the last 3 millisecond digits, and then try the Date constructor again. If it fails this time, it'll just return the ZonedDateTime string, which is a mandatory field in the JvmInstance table so it will always contain at least some date information.