### PR TITLE
chore(card): rename the Processors header to Cores

### DIFF
--- a/src/components/RuntimesProcessesAccordion.tsx
+++ b/src/components/RuntimesProcessesAccordion.tsx
@@ -25,7 +25,7 @@ export const instanceDataRows: Array<InstanceInfoTitles> = [
   { id: 'created', title: ' Created' },
   { id: 'eapVersion', title: 'EAP Version' },
   { id: 'appName', title: 'Application' },
-  { id: 'processors', title: 'Processors' },
+  { id: 'processors', title: 'Cores' },
   { id: 'javaVendor', title: 'JVM Vendor' },
   { id: 'versionString', title: 'JVM Version' },
   { id: 'jvmHeapGcDetails', title: 'Garbage Collector Details' },


### PR DESCRIPTION
This quick PR updates the card to rename "Processors" to "Cores".

Before:

![Screenshot from 2024-05-15 10-17-10](https://github.com/RedHatInsights/insights-runtimes-frontend/assets/10425301/9d6f9e66-288a-4513-a85d-147f2e1e6313)

After:

![Screenshot from 2024-05-15 10-16-15](https://github.com/RedHatInsights/insights-runtimes-frontend/assets/10425301/edadaebf-a0d1-41d9-8874-d5b818c4202d)
