### PR TITLE
chore(konflux): add rpms-signature-scan to pipelines

### DIFF
--- a/.tekton/insights-runtimes-frontend-pull-request.yaml
+++ b/.tekton/insights-runtimes-frontend-pull-request.yaml
@@ -402,6 +402,23 @@ spec:
         operator: in
         values:
         - "false"
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0c9667fba291af05997397a32e5e938ccaa46e93a2e14bad228e64a6427c5545
+        - name: kind
+          value: task
+        resolver: bundles    
     - name: sast-snyk-check
       params:
       - name: image-digest

--- a/.tekton/insights-runtimes-frontend-push.yaml
+++ b/.tekton/insights-runtimes-frontend-push.yaml
@@ -399,6 +399,23 @@ spec:
         operator: in
         values:
         - "false"
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0c9667fba291af05997397a32e5e938ccaa46e93a2e14bad228e64a6427c5545
+        - name: kind
+          value: task
+        resolver: bundles   
     - name: sast-snyk-check
       params:
       - name: image-digest


### PR DESCRIPTION
Figured out why the enterprise-contract kept failing, there was a recent change that added a requirement for a new task `rpms-signature-scan` and this has to be manually added to the pipelines.

This PR adds the task to both the PR and on-push pipelines, at what should be the most recent version of the task image.