### PR TITLE
fix(utils): handle [None] workload type

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -22,7 +22,10 @@ export const formatInstancesData = (instances: JvmInstance[]) => {
       instance.title = instance.workload;
     }
     // change the unidentified workload type, and set the title to the application name
-    if (instance.workload === 'Unidentified') {
+    if (
+      instance.workload === 'Unidentified' ||
+      instance.workload === '[None]'
+    ) {
       instance.workload = 'General Java Application';
       if (instance.appName) {
         // if it's an eap instance, use the app name as it's title


### PR DESCRIPTION
There were some backend changes that resulted in `[None]` being the new default value if information is missing. This quick PR handles this value as a workload type by treating it similar to how we handle `Unidentified`.

Before:
![before](https://github.com/user-attachments/assets/1fb7dc8d-5de2-4adb-90fc-1c3291914e80)

After:
![after](https://github.com/user-attachments/assets/2e3b9fa3-0d28-4b26-8f9b-3fee29339ac0)
