### PR TITLE
chore(tekton): remove JAVA_COMMUNITY_DEPENDENCIES from pipeline results

### DIFF
--- a/.tekton/insights-runtimes-frontend-pull-request.yaml
+++ b/.tekton/insights-runtimes-frontend-pull-request.yaml
@@ -135,9 +135,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:

--- a/.tekton/insights-runtimes-frontend-push.yaml
+++ b/.tekton/insights-runtimes-frontend-push.yaml
@@ -132,9 +132,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:


### PR DESCRIPTION
The latest Konflux update PR (https://github.com/RedHatInsights/insights-runtimes-frontend/pull/65) is failing with: `Failed to resolve pipeline result reference for "insights-runtimes-frontend-on-pull-request-kq24f" with error %!w(*fmt.wrapError=&{invalid pipeline result "JAVA_COMMUNITY_DEPENDENCIES": "JAVA_COMMUNITY_DEPENDENCIES" is not a named result returned by pipeline task "build-container" 0xc0140556b0})`

That PR contains a migration from v0.2 -> v0.3 for task-buildah, but there are missing migration documentation instructing users to remove the `JAVA_COMMUNITY_DEPENDENCIES` results from the pipelines if they aren't being used. This PR removes that result from both the PR and push pipelines.
