### PR TITLE
chore(RHINENG-16166): migrate frontend builds to use shared Dockerfile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build-tools"]
+	path = build-tools
+	url = https://github.com/RedHatInsights/insights-frontend-builder-common.git

--- a/.tekton/insights-runtimes-frontend-pull-request.yaml
+++ b/.tekton/insights-runtimes-frontend-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: ./Dockerfile
+    value: build-tools/Dockerfile
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -207,66 +207,6 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: parse-build-deploy-script
-      params:
-        - name: path-context
-          value: $(params.path-context)
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/RedHatInsights/konflux-consoledot-frontend-build
-          - name: revision
-            value: 21943074a62f1f3c26297d31b4b7a5648ea7f82a
-          - name: pathInRepo
-            value: tasks/parse-build-deploy-script/parse-build-deploy-script.yaml
-      workspaces:
-      - name: source
-        workspace: workspace
-      runAfter:
-      - clone-repository
-    - name: create-frontend-dockerfile
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/RedHatInsights/konflux-consoledot-frontend-build
-          - name: revision
-            value: 21943074a62f1f3c26297d31b4b7a5648ea7f82a
-          - name: pathInRepo
-            value: tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
-      workspaces:
-      - name: source
-        workspace: workspace
-      params:
-        - name: path-context
-          value: $(params.path-context)
-        - name: component
-          value: $(tasks.parse-build-deploy-script.results.component)
-        - name: image
-          value: $(tasks.parse-build-deploy-script.results.image)
-        - name: node-build-version
-          value: $(tasks.parse-build-deploy-script.results.node-build-version)
-        - name: quay-expire-time
-          value: $(tasks.parse-build-deploy-script.results.quay-expire-time)
-        - name: npm-build-script
-          value: $(tasks.parse-build-deploy-script.results.npm-build-script)
-        - name: yarn-build-script
-          value: $(tasks.parse-build-deploy-script.results.yarn-build-script)
-        - name: route-path
-          value: $(tasks.parse-build-deploy-script.results.route-path)
-        - name: beta-route-path
-          value: $(tasks.parse-build-deploy-script.results.beta-route-path)
-        - name: preview-route-path
-          value: $(tasks.parse-build-deploy-script.results.preview-route-path)
-        - name: ci-root
-          value: $(tasks.parse-build-deploy-script.results.ci-root)
-        - name: server-name
-          value: $(tasks.parse-build-deploy-script.results.server-name)
-        - name: dist-folder
-          value: $(tasks.parse-build-deploy-script.results.dist-folder)
-      runAfter:
-      - parse-build-deploy-script
     - name: build-container
       params:
       - name: IMAGE
@@ -290,7 +230,6 @@ spec:
         value: $(params.build-args-file)
       runAfter:
       - prefetch-dependencies
-      - create-frontend-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/insights-runtimes-frontend-push.yaml
+++ b/.tekton/insights-runtimes-frontend-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/insights-runtimes-tenant/insights-runtimes-frontend/insights-runtimes-frontend:{{revision}}
   - name: dockerfile
-    value: ./Dockerfile
+    value: build-tools/Dockerfile
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -204,66 +204,6 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: parse-build-deploy-script
-      params:
-        - name: path-context
-          value: $(params.path-context)
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/RedHatInsights/konflux-consoledot-frontend-build
-          - name: revision
-            value: 21943074a62f1f3c26297d31b4b7a5648ea7f82a
-          - name: pathInRepo
-            value: tasks/parse-build-deploy-script/parse-build-deploy-script.yaml
-      workspaces:
-      - name: source
-        workspace: workspace
-      runAfter:
-      - clone-repository
-    - name: create-frontend-dockerfile
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/RedHatInsights/konflux-consoledot-frontend-build
-          - name: revision
-            value: 21943074a62f1f3c26297d31b4b7a5648ea7f82a
-          - name: pathInRepo
-            value: tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
-      workspaces:
-      - name: source
-        workspace: workspace
-      params:
-        - name: path-context
-          value: $(params.path-context)
-        - name: component
-          value: $(tasks.parse-build-deploy-script.results.component)
-        - name: image
-          value: $(tasks.parse-build-deploy-script.results.image)
-        - name: node-build-version
-          value: $(tasks.parse-build-deploy-script.results.node-build-version)
-        - name: quay-expire-time
-          value: $(tasks.parse-build-deploy-script.results.quay-expire-time)
-        - name: npm-build-script
-          value: $(tasks.parse-build-deploy-script.results.npm-build-script)
-        - name: yarn-build-script
-          value: $(tasks.parse-build-deploy-script.results.yarn-build-script)
-        - name: route-path
-          value: $(tasks.parse-build-deploy-script.results.route-path)
-        - name: beta-route-path
-          value: $(tasks.parse-build-deploy-script.results.beta-route-path)
-        - name: preview-route-path
-          value: $(tasks.parse-build-deploy-script.results.preview-route-path)
-        - name: ci-root
-          value: $(tasks.parse-build-deploy-script.results.ci-root)
-        - name: server-name
-          value: $(tasks.parse-build-deploy-script.results.server-name)
-        - name: dist-folder
-          value: $(tasks.parse-build-deploy-script.results.dist-folder)
-      runAfter:
-      - parse-build-deploy-script
     - name: build-container
       params:
       - name: IMAGE
@@ -287,7 +227,6 @@ spec:
         value: $(params.build-args-file)
       runAfter:
       - prefetch-dependencies
-      - create-frontend-dockerfile
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
To comply with the requirements for Konflux migrations, the frontend apps are being asked ot use a shared Dockerfile for builds.